### PR TITLE
fix: remove unused expiration logic from storage utilities

### DIFF
--- a/src/storage.js
+++ b/src/storage.js
@@ -1,24 +1,18 @@
-function store(storage, key, data, timeout = null) {
-  const expiration = timeout && moment().add(timeout, "seconds").format();
-  storage.setItem(key, JSON.stringify({data, expiration}));
+function store(storage, key, data) {
+  storage.setItem(key, JSON.stringify({data}));
 }
 
 function retrieve(storage, key, data = null) {
   try {
-    const item = JSON.parse(storage.getItem(key)),
-      expired = !!item.expiration && moment(item.expiration) < moment();
-    if (expired) {
-      storage.removeItem(key);
-      return data;
-    }
+    const item = JSON.parse(storage.getItem(key));
     return item.data || data;
   } catch (err) {
     return data;
   }
 }
 
-export function localStore(key, data, timeout = null) {
-  store(localStorage, key, data, timeout);
+export function localStore(key, data) {
+  store(localStorage, key, data);
 }
 
 export function localRetrieve(key, data = null) {


### PR DESCRIPTION
The expiration parameter was always null and the moment library was not imported. Simplified storage utilities to basic localStorage get/set operations.