### PR TITLE
feat: migrate from axios to fetch API

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "dist"
   ],
   "dependencies": {
-    "axios": "^0.21.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-xml-parser": "^1.1.6"

--- a/src/fetchUtils.js
+++ b/src/fetchUtils.js
@@ -1,0 +1,108 @@
+class FetchError extends Error {
+  constructor(message, response, isAborted = false) {
+    super(message);
+    this.name = 'FetchError';
+    this.response = response;
+    this.isAborted = isAborted;
+  }
+}
+
+export function isAbortError(error) {
+  return error instanceof FetchError && error.isAborted;
+}
+
+export async function fetchWithRetry(url, options = {}, retryConfig = {}) {
+  const { maxRetries = 0, retryCondition, onRetry } = retryConfig;
+  let lastError;
+  
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const response = await fetch(url, options);
+      
+      if (!response.ok && (!retryCondition || retryCondition(response))) {
+        throw new FetchError(`HTTP error! status: ${response.status}`, response);
+      }
+      
+      return response;
+    } catch (error) {
+      if (error.name === 'AbortError') {
+        throw new FetchError('Request aborted', null, true);
+      }
+      
+      lastError = error;
+      
+      if (attempt < maxRetries && (!retryCondition || retryCondition(error.response))) {
+        if (onRetry) {
+          await onRetry(error, attempt);
+        }
+        continue;
+      }
+      
+      throw error;
+    }
+  }
+  
+  throw lastError;
+}
+
+export function createFetchInstance() {
+  const interceptors = {
+    response: []
+  };
+  
+  return {
+    interceptors,
+    
+    async request(config) {
+      const { url, method = 'GET', data, headers = {}, signal, ...otherOptions } = config;
+      
+      const options = {
+        method,
+        headers: { ...headers },
+        signal,
+        ...otherOptions
+      };
+      
+      if (data) {
+        if (typeof data === 'string') {
+          options.body = data;
+          if (!options.headers['Content-Type']) {
+            options.headers['Content-Type'] = 'application/x-www-form-urlencoded';
+          }
+        } else if (data instanceof FormData) {
+          options.body = data;
+        } else {
+          options.body = JSON.stringify(data);
+          if (!options.headers['Content-Type']) {
+            options.headers['Content-Type'] = 'application/json';
+          }
+        }
+      }
+      
+      let response;
+      try {
+        response = await fetch(url, options);
+      } catch (error) {
+        if (error.name === 'AbortError') {
+          throw new FetchError('Request aborted', null, true);
+        }
+        throw error;
+      }
+      
+      // Run response interceptors
+      for (const interceptor of this.interceptors.response) {
+        try {
+          response = await interceptor.onFulfilled(response, config);
+        } catch (error) {
+          if (interceptor.onRejected) {
+            response = await interceptor.onRejected(error, config);
+          } else {
+            throw error;
+          }
+        }
+      }
+      
+      return response;
+    }
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2215,13 +2215,6 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.0.tgz#a17b3a8ea811060e74d47d306122400ad4497ae2"
   integrity sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==
 
-axios@^0.21.1:
-  version "0.21.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
-  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
-  dependencies:
-    follow-redirects "^1.10.0"
-
 axobject-query@^2.0.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.1.2.tgz#2bdffc0371e643e5f03ba99065d5179b9ca79799"
@@ -4856,7 +4849,7 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-follow-redirects@^1.0.0, follow-redirects@^1.10.0:
+follow-redirects@^1.0.0:
   version "1.13.3"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.3.tgz#e5598ad50174c1bc4e872301e82ac2cd97f90267"
   integrity sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==


### PR DESCRIPTION
- Replace axios with native fetch API throughout the codebase
- Implement custom fetch wrapper with retry logic and AbortController support
- Maintain same retry behavior for Dymo service port scanning (41951-41953)
- Replace CancelToken with AbortController for request cancellation
- Remove axios dependency from package.json
- All existing functionality preserved with native browser APIs